### PR TITLE
补充echarts缺少的配置

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,32 +85,6 @@ Listening on port 5210 ...
 ![chrome_history_percent](screenshots/percent.png)
 ![chrome_history_table](screenshots/table.png)
 
-### 3.1 启动服务时出现的一些问题及解决方法
-
-### 3.1.1 以下是将node从0.12版升级到最新版后，启动时遇到的一些问题和解决方法
-
-如1，在确保将node升级到4.0.0版本以上，并安装所需依赖后，启动时若遇到以下提示错误信息：
-
-`Cannot find module '/chrome-history-stat/node_modules/sqlite3/lib/binding/node-v47-darwin-x64/node_sqlite3.node'`
-
-定位到问题：在将`node`从`0.12`通过
-
-`npm install -g n`
-
-`n stable`
-
-升级到node.js最新稳定版时，经检查`npm`和`node-gyp`的版本并没有升级，于是执行
-
-`sudo npm install npm -g`
-
-npm版本从`2.14.2`升级到`3.5.3`
-
-`sudo npm install node-gyp -g`
-
-node-gyp版本从`0.6.14`升级到`3.2.1`
-
-重新启动服务成功
-
 ### 4. 数据导出
 当然，除了在线浏览，还可以把数据导出为 CSV 文件。直接在命令行执行下面的命令：
 ```

--- a/README.md
+++ b/README.md
@@ -85,6 +85,32 @@ Listening on port 5210 ...
 ![chrome_history_percent](screenshots/percent.png)
 ![chrome_history_table](screenshots/table.png)
 
+### 3.1 启动服务时出现的一些问题及解决方法
+
+### 3.1.1 以下是将node从0.12版升级到最新版后，启动时遇到的一些问题和解决方法
+
+如1，在确保将node升级到4.0.0版本以上，并安装所需依赖后，启动时若遇到以下提示错误信息：
+
+`Cannot find module '/chrome-history-stat/node_modules/sqlite3/lib/binding/node-v47-darwin-x64/node_sqlite3.node'`
+
+定位到问题：在将`node`从`0.12`通过
+
+`npm install -g n`
+
+`n stable`
+
+升级到node.js最新稳定版时，经检查`npm`和`node-gyp`的版本并没有升级，于是执行
+
+`sudo npm install npm -g`
+
+npm版本从`2.14.2`升级到`3.5.3`
+
+`sudo npm install node-gyp -g`
+
+node-gyp版本从`0.6.14`升级到`3.2.1`
+
+重新启动服务成功
+
 ### 4. 数据导出
 当然，除了在线浏览，还可以把数据导出为 CSV 文件。直接在命令行执行下面的命令：
 ```

--- a/assets/js/chrome.js
+++ b/assets/js/chrome.js
@@ -7,6 +7,7 @@ function initDailyVisits(ec) {
     //--- 折柱 ---
     var dailyVisitsChart = ec.init(document.getElementById('dailyVisits'));
     dailyVisitsChart.setOption({
+        color: ['#23B7E5'],
         title : {
             text : '2015 年 Chrome 历史浏览量',
             subtext : '^_^'
@@ -49,11 +50,13 @@ function initDailyVisits(ec) {
         ],
         yAxis : [
             {
+                name: '访问量',
                 type : 'value'
             }
         ],
         series : [
             {
+                name: '访问量',
                 type: 'line',
                 showAllSymbol: true,
                 symbolSize: function (value){


### PR DESCRIPTION
原图中可看到这里是灰色的

![snip20160115_14](https://cloud.githubusercontent.com/assets/8725006/12346600/e0ca2650-bb90-11e5-85cf-5a5913b7618c.png)

这是原项目中启用了legend但是没有和线条联动起来，请见[echarts官方文档](http://echarts.baidu.com/echarts2/doc/doc.html#Series)如下：

![snip20160115_15](https://cloud.githubusercontent.com/assets/8725006/12346647/324567e2-bb91-11e5-80f4-c9e81be1d0b9.png)

于是添加了name值，并添加了y轴的坐标，同时将默认的橘黄色颜色改为蓝色，效果如下：

![snip20160115_10](https://cloud.githubusercontent.com/assets/8725006/12346629/0faa93f6-bb91-11e5-97b6-d56714fc43c8.png)
